### PR TITLE
:sparkles: feat: Update plugin compatibility for IntelliJ 2022.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ pluginVersion=2024.3.10
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild=211
-pluginUntilBuild=241.*
+pluginUntilBuild=242.*
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType=IU
 platformVersion=2021.2.1


### PR DESCRIPTION
# Changes
The changes in this commit update the `pluginUntilBuild` property in the `gradle.properties` file to extend the compatibility of the plugin to work with IntelliJ Platform versions up to 2022.1 (242.*). This ensures that the plugin can be used with the latest version of IntelliJ IDEA.

Closes #3 
Closes #4 